### PR TITLE
Do not force `isDevelopingAddon`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,6 @@ let minimatch = require('minimatch');
 
 module.exports = {
   name: 'ember-cli-deploy-appshell',
-  isDevelopingAddon() {
-    return true;
-  },
 
   included(app) {
     this.app = app;


### PR DESCRIPTION
In general, this will make linting errors and whatnot show up in consuming apps.  It is very useful to turn this on while developing (especially while linking) but should be removed before publishing.
