### PR TITLE
Specify required node engine version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": "https://github.com/ef4/ember-cli-deploy-appshell",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 4.0.0"
   },
   "author": "Edward Faulkner <ef@alum.mit.edu>",
   "license": "MIT",


### PR DESCRIPTION
This package uses `let` and template strings (which are only available on newer Node).  I think it would probably be OK to specify Node 0.12 or something, but `>= 4.0.0` seems reasonable.

---

If you would prefer that I make it work for Node 0.10+, I can submit an alternate PR removing all the niceties...
